### PR TITLE
revert to sysvinit script

### DIFF
--- a/etc/nova-agent.redhat
+++ b/etc/nova-agent.redhat
@@ -1,11 +1,101 @@
-description "Nova Agent upstart script"
-author      "Daniel Wallace"
+#!/bin/sh
+#
+# nova-agent   Agent for setting up clean servers on Xen
+#
+# chkconfig:   2345 15 85
+# description: Starts and stops the nova-agent daemon.
 
-start on networking or runlevel [2345]
-stop on runlevel [!2345]
+### BEGIN INIT INFO
+# Provides:          nova-agent
+# Required-Start:    $all
+# Required-Stop:
+# Should-Start:
+# Should-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: nova-agent daemon
+# Description:       Starts and stops the nova-agent daemon.
+### END INIT INFO
 
-respawn
-respawn limit 10 5
-umask 022
+# Source function library.
+. /etc/rc.d/init.d/functions
 
-exec /usr/bin/nova-agent -o /var/log/nova-agent.log
+prog="nova-agent"
+exec="/usr/bin/$prog"
+lockfile="/var/lock/subsys/$prog"
+
+start() {
+    [ -x $exec ] || exit 5
+    echo -n $"Starting $prog: "
+    daemon $exec
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc $prog
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    restart
+}
+
+force_reload() {
+    restart
+}
+
+rh_status() {
+    status $prog
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 7
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+        exit 2
+        ;;
+esac
+exit $?
+
+# https://fedoraproject.org/wiki/EPEL:SysVInitScript


### PR DESCRIPTION
Based on https://fedoraproject.org/wiki/EPEL:SysVInitScript.  Needed because the upstart job doesn't have packaging integration with %post, %preun, and %postun scriptlets.